### PR TITLE
feature: add application flavours

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Staging",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main_staging.dart",
+      "args": ["--flavor", "staging"]
+    },
+    {
+      "name": "Production",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "args": ["--flavor", "prod"]
+    }
+  ]
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -60,6 +60,23 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    flavorDimensions "app"
+
+    productFlavors {
+
+        staging {
+            dimension "app"
+            resValue "string", "app_name", "Staging Flutter Template"
+            applicationIdSuffix ".staging"
+            versionNameSuffix "-stg"
+        }
+
+        prod {
+            dimension "app"
+            resValue "string", "app_name", "Flutter Template"
+        }
+    }
 }
 
 flutter {

--- a/lib/config/flavor_config.dart
+++ b/lib/config/flavor_config.dart
@@ -1,0 +1,30 @@
+enum Flavor { staging, production }
+
+class FlavorValues {
+  const FlavorValues({
+    required this.baseUrl,
+    required this.authorization,
+  });
+  final String baseUrl;
+  final String authorization;
+}
+
+class FlavorConfig {
+  factory FlavorConfig({required Flavor flavor, required FlavorValues values}) {
+    _instance ??= FlavorConfig._internal(flavor, flavor.toString().split('.').last, values);
+    return _instance!;
+  }
+
+  FlavorConfig._internal(this.flavor, this.name, this.values);
+
+  final Flavor flavor;
+  final String name;
+  final FlavorValues values;
+  static FlavorConfig? _instance;
+
+  static FlavorConfig? get instance => _instance;
+
+  static bool isProduction() => _instance?.flavor == Flavor.production;
+
+  static bool isStaging() => _instance?.flavor == Flavor.staging;
+}

--- a/lib/main_base.dart
+++ b/lib/main_base.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_base_template_1/config/flavor_config.dart';
+
+void runMain({
+  required FlavorConfig Function() configInit,
+  required bool dumpErrorToConsole,
+}) async {
+  runZonedGuarded<Future<void>>(() async {
+    await _init(configInit: configInit);
+  }, (error, stack) {
+    final details = FlutterErrorDetails(exception: error, stack: stack);
+    if (dumpErrorToConsole) {
+      FlutterError.dumpErrorToConsole(details);
+    }
+    // Record errors to analytics here, like FirebaseCrashlytics etc.
+  });
+}
+
+/// A Helper method that is used for initialise app services like
+/// firebase, remote config, or other 3rd party SDK dependences etc.
+/// All the services that needs to be initialised at the start of the app
+/// will be added here.
+Future<void> _init({
+  required FlavorConfig Function() configInit,
+}) async {
+  // initialize widget binding
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // init flavors specific values
+  configInit();
+}

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_base_template_1/config/flavor_config.dart';
+import 'main_base.dart';
+
+void main() async {
+  // disable debug print on production release mode
+  if (kReleaseMode) {
+    debugPrint = (String? message, {int? wrapWidth}) {};
+  }
+
+  runMain(
+    configInit: () => FlavorConfig(
+      flavor: Flavor.production,
+      values: const FlavorValues(
+        baseUrl: '',
+        authorization: '',
+      ),
+    ),
+    dumpErrorToConsole: true,
+  );
+}

--- a/lib/main_staging.dart
+++ b/lib/main_staging.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_base_template_1/config/flavor_config.dart';
+import 'main_base.dart';
+
+void main() async {
+  runMain(
+    configInit: () => FlavorConfig(
+      flavor: Flavor.staging,
+      values: const FlavorValues(
+        baseUrl: '',
+        authorization: '',
+      ),
+    ),
+    dumpErrorToConsole: true,
+  );
+}


### PR DESCRIPTION
### Why is this PR required?
Need to define the different available environments/flavours for the app.


### Important links
NA


### What this PR does
- Define staging and prod flavours in build.gradle
- Create staging and prod entry point classes.
- Create a base class for initialising app services.

`NOTE`: In this PR the linking of the app to available flavours in not completed. 

### Videos/Screenshots
NA