### PR TITLE
feature: add bloc and states

### DIFF
--- a/lib/modules/app/base_app_module.dart
+++ b/lib/modules/app/base_app_module.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_base_template_1/modules/detail/pages/detail_page.dart';
-import 'package:flutter_base_template_1/modules/home/pages/home_page.dart';
+import 'package:flutter_base_template_1/modules/detail/detail_module.dart';
+import 'package:flutter_base_template_1/modules/home/home_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class BaseAppModule extends Module {
@@ -8,12 +8,14 @@ class BaseAppModule extends Module {
 
   @override
   List<ModularRoute> get routes => [
-        // TODO(kaxp): Update the ChildRoute to ModuleRoute in follow-up PR.
-        ChildRoute(
+        ModuleRoute(
           BaseAppModuleRoutes.homePage,
-          child: (context, args) => HomePage(),
+          module: HomeModule(),
         ),
-        ChildRoute(BaseAppModuleRoutes.detailPage, child: (context, args) => DetailPage()),
+        ModuleRoute(
+          BaseAppModuleRoutes.detailPage,
+          module: DetailModule(),
+        ),
       ];
 }
 

--- a/lib/modules/detail/bloc/detail_bloc.dart
+++ b/lib/modules/detail/bloc/detail_bloc.dart
@@ -1,0 +1,8 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'detail_state.dart';
+
+class DetailBloc extends Cubit<DetailState> {
+  DetailBloc() : super(DetailInitial());
+}

--- a/lib/modules/detail/bloc/detail_state.dart
+++ b/lib/modules/detail/bloc/detail_state.dart
@@ -1,0 +1,13 @@
+part of 'detail_bloc.dart';
+
+abstract class DetailState extends Equatable {
+  const DetailState();
+  @override
+  List<Object?> get props => [];
+}
+
+class DetailInitial extends DetailState {}
+
+class DetailLoading extends DetailState {}
+
+class DetailLoaded extends DetailState {}

--- a/lib/modules/detail/detail_module.dart
+++ b/lib/modules/detail/detail_module.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_base_template_1/modules/detail/bloc/detail_bloc.dart';
+import 'package:flutter_base_template_1/modules/detail/pages/detail_page.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+class DetailModule extends Module {
+  @override
+  List<Bind> get binds => [
+        Bind<DetailBloc>((i) {
+          return DetailBloc();
+        }),
+      ];
+
+  @override
+  List<ModularRoute> get routes => [
+        ChildRoute(
+          Modular.initialRoute,
+          child: (context, args) => DetailPage(),
+        ),
+      ];
+}
+
+class DetailRoute {
+  static const String moduleRoute = '/detail/';
+}

--- a/lib/modules/detail/pages/detail_page.dart
+++ b/lib/modules/detail/pages/detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_base_template_1/generated/l10n.dart';
+import 'package:flutter_base_template_1/modules/home/home_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class DetailPage extends StatelessWidget {
@@ -12,7 +13,11 @@ class DetailPage extends StatelessWidget {
       ),
       body: Center(
         child: ElevatedButton(
-          onPressed: () => Modular.to.navigate('/'),
+          onPressed: () {
+            Modular.to.pushNamed(
+              HomeRoute.moduleRoute,
+            );
+          },
           child: Text(
             S.current.backToHome,
           ),

--- a/lib/modules/home/bloc/home_bloc.dart
+++ b/lib/modules/home/bloc/home_bloc.dart
@@ -1,0 +1,8 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'home_state.dart';
+
+class HomeBloc extends Cubit<HomeState> {
+  HomeBloc() : super(HomeInitial());
+}

--- a/lib/modules/home/bloc/home_state.dart
+++ b/lib/modules/home/bloc/home_state.dart
@@ -1,0 +1,13 @@
+part of 'home_bloc.dart';
+
+abstract class HomeState extends Equatable {
+  const HomeState();
+  @override
+  List<Object?> get props => [];
+}
+
+class HomeInitial extends HomeState {}
+
+class HomeLoading extends HomeState {}
+
+class HomeLoaded extends HomeState {}

--- a/lib/modules/home/home_module.dart
+++ b/lib/modules/home/home_module.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_base_template_1/modules/home/bloc/home_bloc.dart';
+import 'package:flutter_base_template_1/modules/home/pages/home_page.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+class HomeModule extends Module {
+  @override
+  List<Bind> get binds => [
+        Bind<HomeBloc>((i) {
+          return HomeBloc();
+        }),
+      ];
+
+  @override
+  List<ModularRoute> get routes => [
+        ChildRoute(
+          Modular.initialRoute,
+          child: (context, args) => HomePage(),
+        ),
+      ];
+}
+
+class HomeRoute {
+  static const String moduleRoute = '/';
+}

--- a/lib/modules/home/pages/home_page.dart
+++ b/lib/modules/home/pages/home_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_base_template_1/generated/l10n.dart';
-import 'package:flutter_base_template_1/modules/app/base_app_module.dart';
+import 'package:flutter_base_template_1/modules/detail/detail_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class HomePage extends StatelessWidget {
@@ -13,9 +13,11 @@ class HomePage extends StatelessWidget {
       ),
       body: Center(
         child: ElevatedButton(
-          onPressed: () => Modular.to.navigate(
-            BaseAppModuleRoutes.detailPage,
-          ),
+          onPressed: () {
+            Modular.to.pushNamed(
+              DetailRoute.moduleRoute,
+            );
+          },
           child: Text(
             S.current.navigateToDetailPage,
           ),


### PR DESCRIPTION
### Why is this PR required
We need to add bloc and state for the home and detail module.


### Important links
NA


### What this PR does
- Add home module
  - Add bloc and states for home
- Add detail module
  - Add bloc and states for detail
- Update navigation on home and detail pages.


### Videos/Screenshots

https://github.com/kaxp/flutter_setup_template_1/assets/25891817/e68cd2e3-a098-48eb-a7d4-55fcb330b6a3


