### PR TITLE
test: dio error extension methods

### DIFF
--- a/test/utils/error_extension_test.dart
+++ b/test/utils/error_extension_test.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_base_template_1/generated/l10n.dart';
+import 'package:flutter_base_template_1/utils/dio_error_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'mock_dio_error.dart';
+
+void main() async {
+  final localeStrings = await S.load(const Locale.fromSubtags(languageCode: 'en')); // mimic localization delegate init
+
+  group('test errorMessage() extension method for DioError', () {
+    test('will return "message" value from first error Data', () {
+      final dioError = MockDioError(json: '''
+          {
+              "errorCode": "1000",
+              "message": "Sorry, something went wrong",
+              "detail": "Api token not valid"
+          }
+      ''');
+
+      expect(dioError.errorMessage(), 'Sorry, something went wrong');
+    });
+
+    test('will return network error message for DioErrorType.connectTimeout', () {
+      final dioError = MockDioError(type: DioErrorType.connectionTimeout);
+      expect(dioError.errorMessage(), localeStrings.networkErrorMessage);
+    });
+
+    test('will return network error message for DioErrorType.sendTimeout', () {
+      final dioError = MockDioError(type: DioErrorType.sendTimeout);
+      expect(dioError.errorMessage(), localeStrings.networkErrorMessage);
+    });
+
+    test('will return network error message for DioErrorType.receiveTimeout', () {
+      final dioError = MockDioError(type: DioErrorType.receiveTimeout);
+      expect(dioError.errorMessage(), localeStrings.networkErrorMessage);
+    });
+
+    test('will return request canceled error message for DioErrorType.cancel', () {
+      final dioError = MockDioError(type: DioErrorType.cancel);
+      expect(dioError.errorMessage(), localeStrings.networkRequestCanceled);
+    });
+
+    test('will return network error message for DioErrorType.badResponse and error is SocketException',
+        () async {
+      final dioError = MockDioError(type: DioErrorType.badResponse, error: const SocketException('no internet'));
+      expect(dioError.errorMessage(), localeStrings.networkErrorMessage);
+    });
+
+    test('will return something went wrong error message for DioErrorType.badResponse', () async {
+      final dioError = MockDioError(type: DioErrorType.badResponse);
+      expect(dioError.errorMessage(), localeStrings.unknownError);
+    });
+
+    test('will return invalid clientId error message for DioErrorType.badCertificate', () async {
+      final dioError = MockDioError(type: DioErrorType.badCertificate);
+      expect(dioError.errorMessage(), localeStrings.invalidClientIdError);
+    });
+  });
+}

--- a/test/utils/mock_dio_error.dart
+++ b/test/utils/mock_dio_error.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:mockito/mockito.dart';
+
+const String validJson = '''
+          {
+              "detail": "error",
+              "message": "Not Found",
+              "errorCode": 404
+          }
+      ''';
+
+class MockDioError extends Mock implements DioError {
+  MockDioError({
+    String json = validJson,
+    this.type = DioErrorType.badResponse,
+    this.error,
+    this.message = '',
+  }) : response = Response(
+          requestOptions: RequestOptions(path: 'url'),
+          data: jsonDecode(json),
+        );
+
+  final Response response;
+  final DioErrorType type;
+  final dynamic error;
+  final String message;
+
+  MockDioError.withErrorData({
+    String errorCode = '1000',
+    String title = 'title',
+    String detail = 'detail',
+    this.message = '',
+  })  : response = Response(
+          requestOptions: RequestOptions(path: 'url'),
+          data: {
+            'errors': [
+              {
+                'errorCode': errorCode,
+                'title': title,
+                'detail': detail,
+              }
+            ]
+          },
+        ),
+        type = DioErrorType.badResponse,
+        error = null;
+}


### PR DESCRIPTION
### Why is this PR required
We need to add tests for `errorMessage() `method of `DioErrorExt` class


### Important links
NA


### What this PR does
- Add mock of DioError
- Write tests for errorMessage method of DioErrorExt class.


### Videos/Screenshots
NA
