### PR TITLE
feature: add favourite event functionality

### DIFF
--- a/lib/components/organisms/list_views/events_list_view.dart
+++ b/lib/components/organisms/list_views/events_list_view.dart
@@ -10,11 +10,9 @@ import 'package:flutter_modular/flutter_modular.dart';
 class EventsListView extends StatelessWidget {
   const EventsListView({
     super.key,
-    this.isFavorite = false,
     required this.events,
   });
 
-  final bool isFavorite;
   final List<Event> events;
 
   @override
@@ -50,7 +48,7 @@ class EventsListView extends StatelessWidget {
                     ),
                   ),
                   Visibility(
-                    visible: isFavorite,
+                    visible: events[index].isFavourite,
                     child: const Positioned(
                       top: 2,
                       left: 0,

--- a/lib/modules/detail/bloc/detail_bloc.dart
+++ b/lib/modules/detail/bloc/detail_bloc.dart
@@ -1,8 +1,32 @@
 import 'package:equatable/equatable.dart';
+import 'package:flutter_base_template_1/modules/home/bloc/home_bloc.dart';
+import 'package:flutter_base_template_1/modules/home/models/events_response.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 
 part 'detail_state.dart';
 
 class DetailBloc extends Cubit<DetailState> {
   DetailBloc() : super(DetailInitial());
+
+  final _homeBloc = Modular.get<HomeBloc>();
+
+  void setInitialPageState(Event event) {
+    if (event.isFavourite) {
+      emit(DetailFavourite());
+    } else {
+      emit(DetailUnFavourite());
+    }
+  }
+
+  void onFavouriteTap(Event event) {
+    _homeBloc.updateFavouriteEventStatus(event.id);
+
+    // TODO(kaxp): Save this data to SharedPrefs.
+    if (state is DetailUnFavourite) {
+      emit(DetailFavourite());
+    } else {
+      emit(DetailUnFavourite());
+    }
+  }
 }

--- a/lib/modules/detail/bloc/detail_state.dart
+++ b/lib/modules/detail/bloc/detail_state.dart
@@ -8,6 +8,6 @@ abstract class DetailState extends Equatable {
 
 class DetailInitial extends DetailState {}
 
-class DetailLoading extends DetailState {}
+class DetailUnFavourite extends DetailState {}
 
-class DetailLoaded extends DetailState {}
+class DetailFavourite extends DetailState {}

--- a/lib/modules/detail/pages/detail_page.dart
+++ b/lib/modules/detail/pages/detail_page.dart
@@ -9,90 +9,117 @@ import 'package:flutter_base_template_1/config/themes/assets/app_colors.dart';
 import 'package:flutter_base_template_1/config/themes/assets/app_fonts.dart';
 import 'package:flutter_base_template_1/constants/spacing_constants.dart';
 import 'package:flutter_base_template_1/generated/l10n.dart';
+import 'package:flutter_base_template_1/modules/detail/bloc/detail_bloc.dart';
 import 'package:flutter_base_template_1/modules/home/models/events_response.dart';
 import 'package:flutter_base_template_1/utils/helpers.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 
-class DetailPage extends StatelessWidget {
+class DetailPage extends StatefulWidget {
   const DetailPage({super.key, required this.event});
 
   final Event event;
 
+  @override
+  State<DetailPage> createState() => _DetailPageState();
+}
+
+class _DetailPageState extends State<DetailPage> {
+  final _detailBloc = Modular.get<DetailBloc>();
+
+  @override
+  void initState() {
+    super.initState();
+    _detailBloc.setInitialPageState(widget.event);
+  }
+
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
-    return Scaffold(
-      appBar: CustomAppBar(
-        titleWidget: Text(
-          S.current.detailPage,
-          style: const TextStyle(
-            color: AppColors.backgroundColor,
-            fontFamily: AppFonts.ratMedium,
-          ),
-        ),
-        isCenter: true,
-        actionWidgets: [
-          IconButton(
-            onPressed: () => {},
-            icon: const Icon(
-              Icons.favorite_border,
+
+    return BlocBuilder<DetailBloc, DetailState>(
+      bloc: _detailBloc,
+      builder: (context, state) {
+        return Scaffold(
+          appBar: CustomAppBar(
+            titleWidget: Text(
+              S.current.detailPage,
+              style: const TextStyle(
+                color: AppColors.backgroundColor,
+                fontFamily: AppFonts.ratMedium,
+              ),
             ),
-          )
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(kSpacingMedium),
-        child: Stack(
-          children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+            isCenter: true,
+            actionWidgets: [
+              IconButton(
+                onPressed: () => _detailBloc.onFavouriteTap(widget.event),
+                icon: state is DetailFavourite
+                    ? const Icon(
+                        Icons.favorite,
+                        color: AppColors.redColor,
+                      )
+                    : const Icon(
+                        Icons.favorite_border,
+                      ),
+              )
+            ],
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(kSpacingMedium),
+            child: Stack(
               children: [
-                Center(
-                  child: EventDetailBanner(
-                    imageUrl: event.performers[0].image,
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: EventDetailBanner(
+                        imageUrl: widget.event.performers[0].image,
+                      ),
+                    ),
+                    const SizedBox(
+                      height: kSpacingMedium,
+                    ),
+                    Header1(
+                      title: widget.event.title,
+                      fontSize: 24,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    const SizedBox(
+                      height: kSpacingXxSmall,
+                    ),
+                    Header3(
+                      title: '${widget.event.venue.city}, ${widget.event.venue.state}',
+                      color: AppColors.lightGreyColor,
+                    ),
+                    const SizedBox(
+                      height: kSpacingXxSmall,
+                    ),
+                    Header3(
+                      title: DateFormatter.formattedFullDateAndTimeWithComma(widget.event.datetimeLocal),
+                      color: AppColors.lightGreyColor,
+                    ),
+                  ],
+                ),
+                Positioned(
+                  bottom: 0,
+                  child: SizedBox(
+                    width: screenWidth - 32,
+                    child: DefaultElevatedButton(
+                      title: S.current.bookNow,
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          CustomSnackbar(
+                            message: S.current.comingSoon,
+                          ),
+                        );
+                      },
+                    ),
                   ),
-                ),
-                const SizedBox(
-                  height: kSpacingMedium,
-                ),
-                Header1(
-                  title: event.title,
-                  fontSize: 24,
-                  fontWeight: FontWeight.w500,
-                ),
-                const SizedBox(
-                  height: kSpacingXxSmall,
-                ),
-                Header3(
-                  title: '${event.venue.city}, ${event.venue.state}',
-                  color: AppColors.lightGreyColor,
-                ),
-                const SizedBox(
-                  height: kSpacingXxSmall,
-                ),
-                Header3(
-                  title: DateFormatter.formattedFullDateAndTimeWithComma(event.datetimeLocal),
-                  color: AppColors.lightGreyColor,
                 ),
               ],
             ),
-            Positioned(
-              bottom: 0,
-              child: SizedBox(
-                width: screenWidth - 32,
-                child: DefaultElevatedButton(
-                  title: S.current.bookNow,
-                  onPressed: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      CustomSnackbar(
-                        message: S.current.comingSoon,
-                      ),
-                    );
-                  },
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/modules/home/bloc/home_bloc.dart
+++ b/lib/modules/home/bloc/home_bloc.dart
@@ -34,6 +34,11 @@ class HomeBloc extends Cubit<HomeState> {
       );
 
       if (response.events.isNotEmpty) {
+        // TODO(kaxp): Fetch this data from SharedPrefs.
+        for (var event in response.events) {
+          event.isFavourite = true;
+        }
+
         emit(
           HomeLoaded(
             events: response.events,
@@ -102,5 +107,20 @@ class HomeBloc extends Cubit<HomeState> {
         ),
       );
     }
+  }
+
+  void updateFavouriteEventStatus(int eventId) {
+    final event = state.events.firstWhere((element) => element.id == eventId);
+    event.isFavourite = !event.isFavourite;
+    emit(
+      HomeLoaded(
+        events: state.events,
+        searchQuery: state.searchQuery!,
+        hasReachedEnd: state.hasReachedEnd,
+        page: state.page,
+        totalPage: state.totalPage,
+        timeStamp: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
   }
 }

--- a/lib/modules/home/bloc/home_state.dart
+++ b/lib/modules/home/bloc/home_state.dart
@@ -7,6 +7,7 @@ abstract class HomeState extends Equatable {
     this.page = 1,
     this.hasReachedEnd = true,
     this.totalPage = 1,
+    this.timeStamp
   });
 
   final List<Event> events;
@@ -14,9 +15,10 @@ abstract class HomeState extends Equatable {
   final int page;
   final bool hasReachedEnd;
   final int totalPage;
+  final int? timeStamp;
 
   @override
-  List<Object?> get props => [events, searchQuery, page, hasReachedEnd, totalPage];
+  List<Object?> get props => [events, searchQuery, page, hasReachedEnd, totalPage, timeStamp,];
 }
 
 class HomeInitial extends HomeState {}
@@ -49,12 +51,14 @@ class HomeLoaded extends HomeState {
     required int page,
     required bool hasReachedEnd,
     required int totalPage,
+    int? timeStamp,
   }) : super(
           events: events,
           searchQuery: searchQuery,
           hasReachedEnd: hasReachedEnd,
           page: page,
           totalPage: totalPage,
+          timeStamp: timeStamp,
         );
 }
 

--- a/lib/modules/home/models/events_response.dart
+++ b/lib/modules/home/models/events_response.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: must_be_immutable
+
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -23,12 +25,13 @@ class EventsResponse extends Equatable {
 
 @JsonSerializable()
 class Event extends Equatable {
-  const Event({
+   Event({
     required this.id,
     required this.performers,
     required this.datetimeLocal,
     required this.title,
     required this.venue,
+    this.isFavourite = false,
   });
 
   final int id;
@@ -37,6 +40,7 @@ class Event extends Equatable {
   final DateTime datetimeLocal;
   final String title;
   final Venue venue;
+  bool isFavourite;
 
   factory Event.fromJson(Map<String, dynamic> json) => _$EventFromJson(json);
 


### PR DESCRIPTION
### Why is this PR required
We need to add functionality to favourite and unfavourite an event.

### Important links
NA

### What this PR does
- Update EventResponse model class to add `isFavourite` member.
-  Add method to the favourite and unfavourite event in detail bloc.
- Integrate detail bloc to view
- Add method to update homepage event list favourite status from the detail page.

### Videos/Screenshots

https://github.com/kaxp/Digital/assets/25891817/59888fdb-d008-47c3-a0fb-f80e3e4dfde3


