### PR TITLE
feature: save favourite events to shared prefs

### DIFF
--- a/lib/main_base.dart
+++ b/lib/main_base.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_base_template_1/config/flavor_config.dart';
+import 'package:flutter_base_template_1/managers/shared_preferences_manager.dart';
 import 'package:flutter_base_template_1/modules/app/base_app_module.dart';
 import 'package:flutter_base_template_1/modules/app/root_app.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -40,4 +41,6 @@ Future<void> _init({
 
   // init flavors specific values
   configInit();
+
+  await sharedPreferencesManager.init();
 }

--- a/lib/managers/shared_preferences_manager.dart
+++ b/lib/managers/shared_preferences_manager.dart
@@ -1,0 +1,30 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+final sharedPreferencesManager = SharedPreferencesManager();
+
+class SharedPreferencesManager {
+  static late SharedPreferences _prefs;
+
+  init() async {
+    _prefs = await SharedPreferences.getInstance();
+  }
+
+  Future<bool> setStringList(String key, List<String>? value) async {
+    if (value != null) {
+      return _prefs.setStringList(key, value);
+    }
+    return false;
+  }
+
+  List<String>? getStringList(String key) {
+    return _prefs.getStringList(key);
+  }
+
+  Future<bool> clearData(String key) {
+    return _prefs.remove(key);
+  }
+}
+
+class SharedPreferencesKeys {
+  static const String favouriteEvents = 'favourite_events';
+}

--- a/lib/modules/app/base_app_module.dart
+++ b/lib/modules/app/base_app_module.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_base_template_1/managers/shared_preferences_manager.dart';
 import 'package:flutter_base_template_1/modules/detail/detail_module.dart';
 import 'package:flutter_base_template_1/modules/home/home_module.dart';
 import 'package:flutter_base_template_1/networking/constants/network_constants.dart';
@@ -15,6 +16,9 @@ class BaseAppModule extends Module {
             ),
           ),
         ),
+        Bind.lazySingleton<SharedPreferencesManager>((i) {
+          return SharedPreferencesManager();
+        })
       ];
 
   @override

--- a/lib/modules/detail/bloc/detail_bloc.dart
+++ b/lib/modules/detail/bloc/detail_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:flutter_base_template_1/managers/shared_preferences_manager.dart';
 import 'package:flutter_base_template_1/modules/home/bloc/home_bloc.dart';
 import 'package:flutter_base_template_1/modules/home/models/events_response.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,6 +11,7 @@ class DetailBloc extends Cubit<DetailState> {
   DetailBloc() : super(DetailInitial());
 
   final _homeBloc = Modular.get<HomeBloc>();
+  final _sharedPrefs = Modular.get<SharedPreferencesManager>();
 
   void setInitialPageState(Event event) {
     if (event.isFavourite) {
@@ -19,14 +21,21 @@ class DetailBloc extends Cubit<DetailState> {
     }
   }
 
-  void onFavouriteTap(Event event) {
+  void onFavouriteTap(Event event) async {
+    await _saveFavouriteEvents(event);
     _homeBloc.updateFavouriteEventStatus(event.id);
 
-    // TODO(kaxp): Save this data to SharedPrefs.
     if (state is DetailUnFavourite) {
       emit(DetailFavourite());
     } else {
       emit(DetailUnFavourite());
     }
+  }
+
+  Future<void> _saveFavouriteEvents(Event event) async {
+    final favouriteEvents = _sharedPrefs.getStringList(SharedPreferencesKeys.favouriteEvents) ?? <String>[];
+    favouriteEvents.add(event.id.toString());
+
+    await _sharedPrefs.setStringList(SharedPreferencesKeys.favouriteEvents, favouriteEvents);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -734,7 +734,7 @@ packages:
     source: hosted
     version: "0.27.7"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "16d3fb6b3692ad244a695c0183fca18cf81fd4b821664394a781de42386bf022"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   logger: ^1.3.0
   mockito: ^5.4.0
   retrofit: ^4.0.1
+  shared_preferences: ^2.1.1
   
 
 dev_dependencies:


### PR DESCRIPTION
### Why is this PR required
We need to save favourite events to shared prefs so that next time on app open we can retain favourite events data.


### Important links
NA


### What this PR does
- Add Shared_preferences plugin
- Add SharedPreferenceManager class
- Save favourite events to prefs in detail bloc
- Fetch favourite events from prefs in home bloc.


### Videos/Screenshots

https://github.com/kaxp/Digital/assets/25891817/06e3196b-a372-47ac-b91b-c50dfae660f7


